### PR TITLE
add Stats module from mirage-net-xen

### DIFF
--- a/src/mirage_net.ml
+++ b/src/mirage_net.ml
@@ -28,6 +28,24 @@ type stats = {
   mutable tx_pkts: int32;
 }
 
+module Stats = struct
+  let create () = { rx_pkts=0l; rx_bytes=0L; tx_pkts=0l; tx_bytes=0L }
+  
+  let rx t size =
+    t.rx_pkts <- Int32.succ t.rx_pkts;
+    t.rx_bytes <- Int64.add t.rx_bytes size
+  
+  let tx t size =
+    t.tx_pkts <- Int32.succ t.tx_pkts;
+    t.tx_bytes <- Int64.add t.tx_bytes size
+  
+  let reset t =
+    t.rx_bytes <- 0L;
+    t.rx_pkts  <- 0l;
+    t.tx_bytes <- 0L;
+    t.tx_pkts  <- 0l
+end
+
 module type S = sig
   type error = private [> Mirage_device.error]
   val pp_error: error Fmt.t

--- a/src/mirage_net.mli
+++ b/src/mirage_net.mli
@@ -85,3 +85,17 @@ module type S = sig
       defaults. *)
 
 end
+
+module Stats : sig
+  val create: unit -> stats
+  (** [create ()] returns a fresh set of zeroed counters *)
+  
+  val rx: stats -> int64 -> unit
+  (** [rx t size] records that we received a packet of length [size] *)
+    
+  val tx: stats -> int64 -> unit
+  (** [tx t size] records that we transmitted a packet of length [size] *)
+  
+  val reset: stats -> unit
+  (** [reset t] resets all packet counters in [t] to 0 *)
+end


### PR DESCRIPTION
This is currently in `mirage-net-xen` but is generally useful shorthand for implementations or users that want to do calculations on the values in `stats`.