### PR TITLE
documentation isn't wrong anymore

### DIFF
--- a/src/mirage_net.mli
+++ b/src/mirage_net.mli
@@ -70,9 +70,7 @@ module type S = sig
   val listen: t -> (buffer -> unit io) -> (unit, error) result io
   (** [listen nf fn] is a blocking operation that calls [fn buf] with
       every packet that is read from the interface. The function can
-      be stopped by calling [disconnect] in the device layer.
-
-      {b XXX}: listen currently runs forever (documentation wrong)! *)
+      be stopped by calling [disconnect] in the device layer. *)
 
   val mac: t -> macaddr
   (** [mac nf] is the MAC address of [nf]. *)


### PR DESCRIPTION
Remove the warning in the docstring, which isn't true anymore; the content in the paragraph above is correct to the best of my knowledge.