### PR TITLE
Fix linking issues with result

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,10 +1,12 @@
-v1.1.0 2017-05-30
------------------
+### v1.1.1 (2017-06-29)
+
+- Fix an issue with linking with the `Result` module on 4.04 on Linux.
+
+### v1.1.0 (2017-05-30)
 
 - Port to [Jbuilder](https://github.com/janestreet/jbuilder).
 
-v1.0.0 2016-12-26
------------------
+### v1.0.0 (2016-12-26)
 
 - Add Stats module from `mirage-net-xen` for common use
 - Initial version, code imported from <https://github.com/mirage/mirage>

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,3 @@
-
 .PHONY: build clean test
 
 build:

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: build clean test
 
 build:
-	jbuilder build @install --dev
+	jbuilder build --dev
 
 test:
 	jbuilder runtest --dev
@@ -9,8 +9,5 @@ test:
 install:
 	jbuilder install
 
-uninstall:
-	jbuilder uninstall
-
 clean:
-	rm -rf _build *.install
+	jbuilder clean

--- a/mirage-net.opam
+++ b/mirage-net.opam
@@ -16,7 +16,8 @@ build: [
 ]
 
 depends: [
-  "jbuilder" {build & >="1.0+beta7"}
+  "jbuilder" {build & >="1.0+beta10"}
   "mirage-device" {>= "1.0.0"}
   "fmt"
 ]
+available: [ocaml-version > "4.02.3"]

--- a/src/jbuild
+++ b/src/jbuild
@@ -1,5 +1,4 @@
 (library
  ((name        mirage_net)
   (public_name mirage-net)
-  (libraries   (fmt mirage-device))
-))
+  (libraries   (fmt mirage-device))))

--- a/src/mirage_net.ml
+++ b/src/mirage_net.ml
@@ -16,8 +16,6 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
-open Result
-
 type error = Mirage_device.error
 let pp_error = Mirage_device.pp_error
 

--- a/src/mirage_net.ml
+++ b/src/mirage_net.ml
@@ -30,15 +30,15 @@ type stats = {
 
 module Stats = struct
   let create () = { rx_pkts=0l; rx_bytes=0L; tx_pkts=0l; tx_bytes=0L }
-  
+
   let rx t size =
     t.rx_pkts <- Int32.succ t.rx_pkts;
     t.rx_bytes <- Int64.add t.rx_bytes size
-  
+
   let tx t size =
     t.tx_pkts <- Int32.succ t.tx_pkts;
     t.tx_bytes <- Int64.add t.tx_bytes size
-  
+
   let reset t =
     t.rx_bytes <- 0L;
     t.rx_pkts  <- 0l;

--- a/src/mirage_net.mli
+++ b/src/mirage_net.mli
@@ -87,13 +87,13 @@ end
 module Stats : sig
   val create: unit -> stats
   (** [create ()] returns a fresh set of zeroed counters *)
-  
+
   val rx: stats -> int64 -> unit
   (** [rx t size] records that we received a packet of length [size] *)
-    
+
   val tx: stats -> int64 -> unit
   (** [tx t size] records that we transmitted a packet of length [size] *)
-  
+
   val reset: stats -> unit
   (** [reset t] resets all packet counters in [t] to 0 *)
 end

--- a/src/mirage_net.mli
+++ b/src/mirage_net.mli
@@ -22,8 +22,6 @@
 
     {e Release %%VERSION%% } *)
 
-open Result
-
 type error = Mirage_device.error
 (** The type for IO operation errors *)
 


### PR DESCRIPTION
Not sure why the CI didn't catch that, but without this, I got on Linux:

```
$ make
jbuilder build @install --dev
    ocamldep src/mirage_net.depends.ocamldep-output
      ocamlc src/mirage_net.{cmi,cmti} (exit 2)
(cd _build/default && /home/samoht/.opam/alcotest/bin/ocamlc.opt -w @a-4-29-40-41-42-44-45-48-58-59-60-40 -strict-sequence -strict-formats -short-paths -keep-locs -g -bin-annot -I /home/samoht/.opam/alcotest/lib/fmt -I /home/samoht/.opam/alcotest/lib/mirage-device -no-alias-deps -I src -o src/mirage_net.cmi -c -intf src/mirage_net.mli)
File "src/mirage_net.mli", line 25, characters 5-11:
Error: Unbound module Result
```

