### PR TITLE
revise mirage_net interface

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ install: wget https://raw.githubusercontent.com/ocaml/ocaml-ci-scripts/master/.t
 script: bash -ex .travis-opam.sh
 env:
   global:
-  - PINS="mirage-net:. mirage-net-lwt:."
+  - PINS="mirage-net.2.0.0:. mirage-net-lwt.2.0.0:."
   matrix:
   - OCAML_VERSION=4.04 PACKAGE="mirage-net" DEPOPTS="mirage-net-lwt"
   - OCAML_VERSION=4.05 PACKAGE="mirage-net" DEPOPTS="mirage-net-lwt"

--- a/lwt/jbuild
+++ b/lwt/jbuild
@@ -1,5 +1,5 @@
 (library
  ((name        mirage_net_lwt)
   (public_name mirage-net-lwt)
-  (libraries   (mirage-net lwt cstruct io-page macaddr))
+  (libraries   (mirage-net lwt cstruct macaddr))
 ))

--- a/lwt/mirage_net_lwt.ml
+++ b/lwt/mirage_net_lwt.ml
@@ -24,6 +24,5 @@
 
 module type S = Mirage_net.S
   with type 'a io = 'a Lwt.t
-   and type page_aligned_buffer = Io_page.t
    and type buffer = Cstruct.t
    and type macaddr = Macaddr.t

--- a/mirage-net-lwt.opam
+++ b/mirage-net-lwt.opam
@@ -23,6 +23,5 @@ depends: [
   "lwt"
   "macaddr"
   "cstruct"
-  "io-page"
 ]
 synopsis: "Network signatures for MirageOS"

--- a/mirage-net-lwt.opam
+++ b/mirage-net-lwt.opam
@@ -19,7 +19,7 @@ depends: [
   "ocaml" {>= "4.04.2"}
   "jbuilder" {build & >="1.0+beta7"}
   "topkg"    {build & >= "0.8.0"}
-  "mirage-net" {>= "1.0.0"}
+  "mirage-net" {>= "2.0.0"}
   "lwt"
   "macaddr"
   "cstruct"

--- a/src/mirage_net.ml
+++ b/src/mirage_net.ml
@@ -2,6 +2,7 @@
  * Copyright (c) 2011-2015 Anil Madhavapeddy <anil@recoil.org>
  * Copyright (c) 2013-2015 Thomas Gazagnaire <thomas@gazagnaire.org>
  * Copyright (c) 2013      Citrix Systems Inc
+ * Copyright (c) 2018      Hannes Mehnert <hannes@mehnert.org>
  *
  * Permission to use, copy, modify, and distribute this software for any
  * purpose with or without fee is hereby granted, provided that the above
@@ -47,14 +48,15 @@ end
 module type S = sig
   type error = private [> Mirage_device.error]
   val pp_error: error Fmt.t
-  type page_aligned_buffer
   type buffer
   type macaddr
   include Mirage_device.S
   val write: t -> buffer -> (unit, error) result io
   val writev: t -> buffer list -> (unit, error) result io
   val listen: t -> (buffer -> unit io) -> (unit, error) result io
+  val allocate_frame : t -> buffer
   val mac: t -> macaddr
+  val mtu: t -> int
   val get_stats_counters: t -> stats
   val reset_stats_counters: t -> unit
 end

--- a/src/mirage_net.ml
+++ b/src/mirage_net.ml
@@ -54,7 +54,7 @@ module type S = sig
   val write: t -> buffer -> (unit, error) result io
   val writev: t -> buffer list -> (unit, error) result io
   val listen: t -> (buffer -> unit io) -> (unit, error) result io
-  val allocate_frame : t -> buffer
+  val allocate_frame: ?size:int -> t -> buffer
   val mac: t -> macaddr
   val mtu: t -> int
   val get_stats_counters: t -> stats

--- a/src/mirage_net.mli
+++ b/src/mirage_net.mli
@@ -68,13 +68,13 @@ module type S = sig
       every packet that is read from the interface. The function can
       be stopped by calling [disconnect] in the device layer. *)
 
-  val allocate_frame : t -> buffer
-  (** [allocate_frame net] allocates a single frame which can be filled
-      and transmitted via [write] on the same interface [net]. The reason for
-      this function is that the network interface is aware of its
-      memory-alignment requirements (i.e. if it requires page-alignment).
-      Using [write] with a buffer allocated from a different network device
-      leads to undefined behaviour. *)
+  val allocate_frame : ?size:int -> t -> buffer
+  (** [allocate_frame ~size net] allocates a single frame of size
+      [min (size mtu)] which can be filled and transmitted via [write] on the
+      same interface [net]. The reason for this function is that the network
+      interface is aware of its memory-alignment requirements (i.e. if it
+      requires page-alignment). Using [write] with a buffer allocated from a
+      different network device leads to undefined behaviour. *)
 
   val mac: t -> macaddr
   (** [mac net] is the MAC address of [net]. *)


### PR DESCRIPTION
- ~~remove unused `writev` (unsure about this, nobody called it though)~~
- provide `mtu : t -> int`
- provide `allocate_frame : t -> buffer`
- remove `type page_aligned_buffer`

//cc @mirage/core 
The new model in respect to allocation of network frames: let the lowest layer do it, it knows best which MTU and alignment characteristics it needs. On the way we can remove `io_page` from higher layers - but a `mirage-net-xen` will hand out properly page-aligned frames - unfortunately I don't know of a good way to ensure whatever buffer `write` gets was previously allocated by `allocate_frame` (while still allowing arbitrary Cstruct.t operations on the buffer). I plan to add `allocate_frame` to each layer in the stack: TCP calls `IP.allocate_frame`, which calls `Ethernet.allocate_frame`, which calls `Netif.allocate_frame`, which does the allocation. On the way back the offset is increased for each layer, The `write` function in each layer encodes its header into the frame and calls `write` on the lower layer.  

PRs
- [ ] provider https://github.com/mirage/mirage-net-solo5/pull/26
- [ ] provider https://github.com/mirage/mirage-vnetif/pull/24
- [ ] provider https://github.com/mirage/mirage-net-unix/pull/44
- [ ] provider https://github.com/mirage/mirage-net-macosx/pull/28
- [ ] consumer (test) https://github.com/mirage/mirage-tcpip/pull/379
- [ ] consumer https://github.com/mirage/ethernet/pull/2
- [ ] provider https://github.com/mirage/mirage-net-xen/pull/78