### PR TITLE
opam: remove the 'build' directive on dune dependency

### DIFF
--- a/mirage-net-lwt.opam
+++ b/mirage-net-lwt.opam
@@ -17,7 +17,7 @@ build: [
 
 depends: [
   "ocaml" {>= "4.04.2"}
-  "dune" {build & >= "1.0"}
+  "dune" {>= "1.0"}
   "mirage-net" {>= "2.0.0"}
   "lwt"
   "macaddr"

--- a/mirage-net.opam
+++ b/mirage-net.opam
@@ -17,7 +17,7 @@ build: [
 
 depends: [
   "ocaml" {>= "4.04.2"}
-  "dune" {build & >= "1.0"}
+  "dune" {>= "1.0"}
   "mirage-device" {>= "1.0.0"}
   "fmt"
 ]


### PR DESCRIPTION
This directive results in failure when downgrading Dune versions, due to version-specific functionality in the Dune language. See https://github.com/ocaml/opam/issues/3850 for more details.