### PR TITLE
compatibility with older mirage

### DIFF
--- a/src/dune
+++ b/src/dune
@@ -1,4 +1,5 @@
 (library
  (name mirage_net)
  (public_name mirage-net)
- (libraries fmt mirage-device cstruct macaddr lwt))
+ (libraries fmt mirage-device cstruct macaddr lwt)
+ (wrapped false))

--- a/src/mirage_net_lwt.ml
+++ b/src/mirage_net_lwt.ml
@@ -1,0 +1,3 @@
+[@@@ocaml.deprecated "This module will be removed from MirageOS 4.0. Please use Mirage_net instead."]
+
+include Mirage_net


### PR DESCRIPTION
this allows a smooth transition path (mirage 3.6.0 --> 3.7.0) with some deprecations.