### PR TITLE
Breaking API: Remove cstruct

### DIFF
--- a/mirage-net.opam
+++ b/mirage-net.opam
@@ -20,7 +20,6 @@ depends: [
   "dune" {>= "1.0"}
   "fmt"
   "macaddr" {>= "4.0.0"}
-  "cstruct" {>= "4.0.0"}
   "lwt" {>= "4.0.0"}
 ]
 synopsis: "Network signatures for MirageOS"

--- a/src/dune
+++ b/src/dune
@@ -1,4 +1,4 @@
 (library
  (name mirage_net)
  (public_name mirage-net)
- (libraries fmt cstruct macaddr lwt))
+ (libraries fmt macaddr lwt))

--- a/src/mirage_net.ml
+++ b/src/mirage_net.ml
@@ -54,7 +54,7 @@ module type S = sig
   type t
   val disconnect : t -> unit Lwt.t
   val write: t -> size:int -> (Bytes.t -> int) -> (unit, error) result Lwt.t
-  val listen: t -> header_size:int -> (Bytes.t -> unit Lwt.t) -> (unit, error) result Lwt.t
+  val listen: t -> header_size:int -> (string -> unit Lwt.t) -> (unit, error) result Lwt.t
   val mac: t -> Macaddr.t
   val mtu: t -> int
   val get_stats_counters: t -> stats

--- a/src/mirage_net.ml
+++ b/src/mirage_net.ml
@@ -53,8 +53,8 @@ module type S = sig
   val pp_error: error Fmt.t
   type t
   val disconnect : t -> unit Lwt.t
-  val write: t -> size:int -> (Cstruct.t -> int) -> (unit, error) result Lwt.t
-  val listen: t -> header_size:int -> (Cstruct.t -> unit Lwt.t) -> (unit, error) result Lwt.t
+  val write: t -> size:int -> (Bytes.t -> int) -> (unit, error) result Lwt.t
+  val listen: t -> header_size:int -> (Bytes.t -> unit Lwt.t) -> (unit, error) result Lwt.t
   val mac: t -> Macaddr.t
   val mtu: t -> int
   val get_stats_counters: t -> stats

--- a/src/mirage_net.ml
+++ b/src/mirage_net.ml
@@ -53,7 +53,7 @@ module type S = sig
   val pp_error: error Fmt.t
   type t
   val disconnect : t -> unit Lwt.t
-  val write: t -> size:int -> (Bytes.t -> int) -> (unit, error) result Lwt.t
+  val write: t -> size:int -> (bytes -> int) -> (unit, error) result Lwt.t
   val listen: t -> header_size:int -> (string -> unit Lwt.t) -> (unit, error) result Lwt.t
   val mac: t -> Macaddr.t
   val mtu: t -> int

--- a/src/mirage_net.mli
+++ b/src/mirage_net.mli
@@ -57,7 +57,7 @@ module type S = sig
   (** Disconnect from the network device. While this might take some time to
       complete, it can never result in an error. *)
 
-  val write: t -> size:int -> (Bytes.t -> int) -> (unit, error) result Lwt.t
+  val write: t -> size:int -> (bytes -> int) -> (unit, error) result Lwt.t
   (** [write net ~size fill] allocates a buffer of length [size], where [size]
      must not exceed the interface maximum packet size ({!mtu} plus Ethernet
      header). The allocated buffer is zeroed and passed to the [fill] function

--- a/src/mirage_net.mli
+++ b/src/mirage_net.mli
@@ -57,7 +57,7 @@ module type S = sig
   (** Disconnect from the network device. While this might take some time to
       complete, it can never result in an error. *)
 
-  val write: t -> size:int -> (Cstruct.t -> int) -> (unit, error) result Lwt.t
+  val write: t -> size:int -> (Bytes.t -> int) -> (unit, error) result Lwt.t
   (** [write net ~size fill] allocates a buffer of length [size], where [size]
      must not exceed the interface maximum packet size ({!mtu} plus Ethernet
      header). The allocated buffer is zeroed and passed to the [fill] function
@@ -65,7 +65,7 @@ module type S = sig
      buffer. When [fill] returns, a sub buffer is put on the wire: the allocated
      buffer from index 0 to the returned length. *)
 
-  val listen: t -> header_size:int -> (Cstruct.t -> unit Lwt.t) -> (unit, error) result Lwt.t
+  val listen: t -> header_size:int -> (Bytes.t -> unit Lwt.t) -> (unit, error) result Lwt.t
   (** [listen ~header_size net fn] waits for a [packet] with size at most
      [header_size + mtu] on the network device. When a [packet] is received, an
      asynchronous task is created in which [fn packet] is called. The ownership

--- a/src/mirage_net.mli
+++ b/src/mirage_net.mli
@@ -65,7 +65,7 @@ module type S = sig
      buffer. When [fill] returns, a sub buffer is put on the wire: the allocated
      buffer from index 0 to the returned length. *)
 
-  val listen: t -> header_size:int -> (Bytes.t -> unit Lwt.t) -> (unit, error) result Lwt.t
+  val listen: t -> header_size:int -> (string -> unit Lwt.t) -> (unit, error) result Lwt.t
   (** [listen ~header_size net fn] waits for a [packet] with size at most
      [header_size + mtu] on the network device. When a [packet] is received, an
      asynchronous task is created in which [fn packet] is called. The ownership


### PR DESCRIPTION
Dear devs,
Continuing the Cstruct-free work, this is a first proposal for mirage-net.
As it's a breaking change, please let me know what is your preferred API shape :)
This PR is conservative in respect with the current allocations situation, but this can be changed to allow upper layers to allocate buffers, and let `write`/`listen` read from/write to them.
Best.